### PR TITLE
player: sustain 1080p60 playback on Android

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -86,8 +86,8 @@ type backendVideoFrame struct {
 
 const maxPooledVideoBuffers = 8
 
-// backendVideoBufferPool keeps decoded RGBA storage independent from the native
-// scaler-owned frame, which is overwritten by the next Scale call.
+// backendVideoBufferPool reuses the tightly packed RGBA storage filled by the
+// native scaler and later uploaded to Ebitengine.
 type backendVideoBufferPool struct {
 	mutex   sync.Mutex
 	buffers [][]byte

--- a/backend_ffi.go
+++ b/backend_ffi.go
@@ -41,8 +41,11 @@ type ffiDecoder struct {
 	decoder *ffmpeg.Decoder
 	info    backendMediaInfo
 
-	outputSampleRate  int
-	scaler            *ffmpeg.Scaler
+	outputSampleRate int
+	scaler           *ffmpeg.Scaler
+	// scaleTarget holds FFmpeg's reference to the most recently filled pooled
+	// RGBA buffer. WrapBuffer releases that reference before each reuse.
+	scaleTarget       ffmpeg.Frame
 	scalerWidth       int
 	scalerHeight      int
 	scalerFormat      ffmpeg.PixelFormat
@@ -149,7 +152,6 @@ func (d *ffiDecoder) ReadFrame(ctx context.Context, videoBuffers *backendVideoBu
 		if frame == nil {
 			return backendFrame{}, io.EOF
 		}
-
 		converted, ok, err := d.convertFrameLocked(frame, videoBuffers)
 		if err != nil {
 			return backendFrame{}, err
@@ -199,26 +201,20 @@ func (d *ffiDecoder) convertVideoFrameLocked(frame *ffmpeg.FrameWrapper, videoBu
 		d.scalerFormat = sourceFormat
 	}
 
-	scaled, err := d.scaler.Scale(frame.Raw())
-	if err != nil {
-		return backendFrame{}, false, err
-	}
-	// Scale returns a scaler-owned raw frame that is overwritten by the next
-	// call. WrapFrame exposes its data pointer and stride; copyFFmpegRGBA detaches
-	// it into reusable, tightly packed storage for ebiten.Image.WritePixels.
-	wrapped := ffmpeg.WrapFrame(scaled, ffmpeg.MediaTypeVideo)
-	stride := wrapped.Linesize(0)
 	rowSize := width * 4
-	if stride < rowSize {
-		return backendFrame{}, false, fmt.Errorf("avebi: go-ffmpeg-ffi returned RGBA stride %d for row size %d", stride, rowSize)
-	}
-	data := wrapped.Data(0)
-	if len(data) < stride*height {
-		return backendFrame{}, false, fmt.Errorf("avebi: go-ffmpeg-ffi returned a truncated RGBA frame")
+	rgba := videoBuffers.get(rowSize * height)
+	if err := d.scaleTarget.WrapBuffer(rgba, width, height, ffmpeg.PixelFormatRGBA); err != nil {
+		videoBuffers.put(rgba)
+		return backendFrame{}, false, fmt.Errorf("wrap RGBA output buffer: %w", err)
 	}
 
-	rgba := videoBuffers.get(rowSize * height)
-	copyFFmpegRGBA(rgba, data, stride, rowSize, height)
+	if err := d.scaler.ScaleTo(d.scaleTarget, frame.Raw()); err != nil {
+		// Release the native reference before returning this buffer to the pool.
+		_ = d.scaleTarget.Free()
+		d.scaleTarget = ffmpeg.Frame{}
+		videoBuffers.put(rgba)
+		return backendFrame{}, false, err
+	}
 
 	pts := ffmpegPTS(frame.PTS(), d.decoder.VideoStream().TimeBase)
 	duration := d.info.Video.FrameDuration()
@@ -233,16 +229,6 @@ func (d *ffiDecoder) convertVideoFrameLocked(frame *ffmpeg.FrameWrapper, videoBu
 			Stride: rowSize,
 		},
 	}, true, nil
-}
-
-func copyFFmpegRGBA(dst, src []byte, stride, rowSize, height int) {
-	if stride == rowSize {
-		copy(dst, src[:len(dst)])
-		return
-	}
-	for row := 0; row < height; row++ {
-		copy(dst[row*rowSize:(row+1)*rowSize], src[row*stride:row*stride+rowSize])
-	}
 }
 
 func (d *ffiDecoder) convertAudioFrameLocked(frame *ffmpeg.FrameWrapper) (backendFrame, bool, error) {
@@ -398,6 +384,10 @@ func (d *ffiDecoder) Close() error {
 	if d.scaler != nil {
 		errs = append(errs, d.scaler.Close())
 		d.scaler = nil
+	}
+	if !d.scaleTarget.IsNil() {
+		errs = append(errs, d.scaleTarget.Free())
+		d.scaleTarget = ffmpeg.Frame{}
 	}
 	if d.decoder != nil {
 		errs = append(errs, d.decoder.Close())

--- a/backend_ffi_integration_test.go
+++ b/backend_ffi_integration_test.go
@@ -59,13 +59,18 @@ func TestFFmpegBackendMedia(t *testing.T) {
 		t.Skip("set AVEBI_TEST_MEDIA to run the FFmpeg integration test")
 	}
 
+	pinnedBefore := ffmpeg.WrappedBufferMemoryUsage()
 	decoder, err := newMediaBackend().Open(context.Background(), mediaPath, backendOpenOptions{
 		OutputSampleRate: 48_000,
 	})
 	if err != nil {
 		t.Fatalf("open media: %v", err)
 	}
+	closed := false
 	t.Cleanup(func() {
+		if closed {
+			return
+		}
 		if err := decoder.Close(); err != nil {
 			t.Errorf("close media: %v", err)
 		}
@@ -93,6 +98,18 @@ func TestFFmpegBackendMedia(t *testing.T) {
 		t.Fatalf("seek to %s: %v", seekTarget, err)
 	}
 	validateFFmpegSeek(t, decoder, seekTarget, wantAudio)
+
+	pinnedDuringDecode := ffmpeg.WrappedBufferMemoryUsage()
+	if pinnedDuringDecode.PinnedBuffers != pinnedBefore.PinnedBuffers+1 {
+		t.Fatalf("wrapped video buffers while decoding = %d, want %d", pinnedDuringDecode.PinnedBuffers, pinnedBefore.PinnedBuffers+1)
+	}
+	if err := decoder.Close(); err != nil {
+		t.Fatalf("close media: %v", err)
+	}
+	closed = true
+	if pinnedAfterClose := ffmpeg.WrappedBufferMemoryUsage(); pinnedAfterClose != pinnedBefore {
+		t.Fatalf("wrapped video buffer usage after Close = %+v, want %+v", pinnedAfterClose, pinnedBefore)
+	}
 }
 
 func TestFFmpegPlayerWithDisabledAudioMedia(t *testing.T) {

--- a/controller_ffi.go
+++ b/controller_ffi.go
@@ -51,9 +51,13 @@ type playbackController interface {
 var _ playbackController = (*ffiLocalController)(nil)
 
 type ffiLocalController struct {
-	mutex   sync.Mutex
-	decoder mediaDecoder
-	info    backendMediaInfo
+	// mutex protects playback state. Native decoder calls are serialized
+	// separately so an audio read cannot hold playback state while decoding.
+	mutex        sync.Mutex
+	readMutex    sync.Mutex
+	decoderMutex sync.Mutex
+	decoder      mediaDecoder
+	info         backendMediaInfo
 
 	state   PlaybackState
 	looping bool
@@ -79,6 +83,10 @@ type ffiLocalController struct {
 	muted              bool
 
 	decodeErr error
+
+	// decodeGeneration invalidates a frame decoded across a seek, reset, or
+	// close while the playback mutex was released.
+	decodeGeneration uint64
 }
 
 func newFFmpegLocalController(decoder mediaDecoder) *ffiLocalController {
@@ -118,7 +126,7 @@ func (c *ffiLocalController) Play() error {
 		if err := c.noLockCloseAudioPlayer(); err != nil {
 			return err
 		}
-		if err := c.decoder.Seek(0); err != nil {
+		if err := c.seekDecoder(0); err != nil {
 			return err
 		}
 		c.noLockResetPlayback(0)
@@ -172,7 +180,7 @@ func (c *ffiLocalController) Stop() error {
 	if err := c.noLockCloseAudioPlayer(); err != nil {
 		return err
 	}
-	if err := c.decoder.Seek(0); err != nil {
+	if err := c.seekDecoder(0); err != nil {
 		return err
 	}
 	c.noLockResetPlayback(0)
@@ -187,9 +195,10 @@ func (c *ffiLocalController) Close() error {
 		return nil
 	}
 	c.closed = true
+	c.decodeGeneration++
 	playerErr := c.noLockCloseAudioPlayer()
 	c.noLockRecycleVideoFrames()
-	decoderErr := c.decoder.Close()
+	decoderErr := c.closeDecoder()
 	c.videoBuffers.clear()
 	return errors.Join(playerErr, decoderErr)
 }
@@ -209,7 +218,7 @@ func (c *ffiLocalController) Seek(position time.Duration) (*backendFrame, error)
 	if err := c.noLockCloseAudioPlayer(); err != nil {
 		return nil, err
 	}
-	if err := c.decoder.Seek(position); err != nil {
+	if err := c.seekDecoder(position); err != nil {
 		return nil, err
 	}
 	c.noLockResetPlayback(position)
@@ -259,7 +268,7 @@ func (c *ffiLocalController) Seek(position time.Duration) (*backendFrame, error)
 // requested target.
 func (c *ffiLocalController) noLockPrimeAfterSeek() (*backendFrame, error) {
 	for {
-		frame, err := c.decoder.ReadFrame(context.Background(), &c.videoBuffers)
+		frame, err := c.readDecoderFrame(context.Background())
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				return c.lastVideo, nil
@@ -322,7 +331,7 @@ func (c *ffiLocalController) noLockPosition(now time.Time) (time.Duration, error
 			if err := c.noLockCloseAudioPlayer(); err != nil {
 				return 0, err
 			}
-			if err := c.decoder.Seek(0); err != nil {
+			if err := c.seekDecoder(0); err != nil {
 				return 0, err
 			}
 			c.noLockResetPlayback(0)
@@ -335,7 +344,7 @@ func (c *ffiLocalController) noLockPosition(now time.Time) (time.Duration, error
 			return 0, nil
 		}
 		position %= c.info.Duration
-		if err := c.decoder.Seek(position); err != nil {
+		if err := c.seekDecoder(position); err != nil {
 			return 0, err
 		}
 		c.noLockRecycleVideoFrames()
@@ -438,11 +447,11 @@ func (c *ffiLocalController) CurrentVideoFrame() (*backendFrame, bool, error) {
 	}
 
 	for c.lastVideo == nil || c.lastVideo.PTS+c.frameDuration() < position {
-		frame, err := c.decoder.ReadFrame(context.Background(), &c.videoBuffers)
+		frame, err := c.readDecoderFrame(context.Background())
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				if c.looping {
-					if err := c.decoder.Seek(0); err != nil {
+					if err := c.seekDecoder(0); err != nil {
 						return nil, false, err
 					}
 					c.noLockRecycleVideoFrames()
@@ -517,13 +526,33 @@ func (c *ffiLocalController) Read(buffer []byte) (int, error) {
 	if len(buffer)&3 != 0 {
 		buffer = buffer[:len(buffer)&(math.MaxInt-3)]
 	}
+	c.readMutex.Lock()
+	defer c.readMutex.Unlock()
+
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
+	if c.closed {
+		return 0, io.EOF
+	}
 
 	served := c.noLockCopyAudio(buffer)
 	buffer = buffer[served:]
 	for len(buffer) > 0 {
-		frame, err := c.decoder.ReadFrame(context.Background(), &c.videoBuffers)
+		generation := c.decodeGeneration
+		// Native decoding can take most of a frame interval. Keep playback state
+		// available to the Ebitengine thread while the audio reader decodes ahead.
+		c.mutex.Unlock()
+		frame, err := c.readDecoderFrame(context.Background())
+		c.mutex.Lock()
+		if c.closed {
+			// Close already cleared the pool; let this final buffer become
+			// unreachable instead of retaining it in a closed controller.
+			return served, io.EOF
+		}
+		if generation != c.decodeGeneration {
+			recycleBackendFrame(&c.videoBuffers, &frame)
+			return served, io.EOF
+		}
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				// The decoder can reach EOF while Oto still has buffered PCM to
@@ -556,6 +585,24 @@ func (c *ffiLocalController) Read(buffer []byte) (int, error) {
 		buffer = buffer[copied:]
 	}
 	return served, nil
+}
+
+func (c *ffiLocalController) readDecoderFrame(ctx context.Context) (backendFrame, error) {
+	c.decoderMutex.Lock()
+	defer c.decoderMutex.Unlock()
+	return c.decoder.ReadFrame(ctx, &c.videoBuffers)
+}
+
+func (c *ffiLocalController) seekDecoder(position time.Duration) error {
+	c.decoderMutex.Lock()
+	defer c.decoderMutex.Unlock()
+	return c.decoder.Seek(position)
+}
+
+func (c *ffiLocalController) closeDecoder() error {
+	c.decoderMutex.Lock()
+	defer c.decoderMutex.Unlock()
+	return c.decoder.Close()
 }
 
 func (c *ffiLocalController) noLockCopyAudio(buffer []byte) int {
@@ -605,6 +652,7 @@ func (c *ffiLocalController) noLockCloseAudioPlayer() error {
 }
 
 func (c *ffiLocalController) noLockResetPlayback(position time.Duration) {
+	c.decodeGeneration++
 	c.noLockRecycleVideoFrames()
 	c.audioQueue = c.audioQueue[:0]
 	c.firstAudioPTS = position

--- a/controller_ffi_test.go
+++ b/controller_ffi_test.go
@@ -50,41 +50,6 @@ func TestSampleRateMismatchPolicy(t *testing.T) {
 	}
 }
 
-func TestFFmpegRGBAFastAndPaddedCopies(t *testing.T) {
-	packed := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
-	gotPacked := make([]byte, len(packed))
-	copyFFmpegRGBA(gotPacked, packed, 8, 8, 2)
-	if !bytes.Equal(gotPacked, packed) {
-		t.Fatalf("packed RGBA copy = %v, want %v", gotPacked, packed)
-	}
-
-	padded := []byte{
-		1, 2, 3, 4, 5, 6, 7, 8, 0, 0, 0, 0,
-		9, 10, 11, 12, 13, 14, 15, 16, 0, 0, 0, 0,
-	}
-	gotPadded := make([]byte, len(packed))
-	copyFFmpegRGBA(gotPadded, padded, 12, 8, 2)
-	if !bytes.Equal(gotPadded, packed) {
-		t.Fatalf("padded RGBA copy = %v, want %v", gotPadded, packed)
-	}
-}
-
-func BenchmarkFFmpegRGBAReuse(b *testing.B) {
-	const width, height = 320, 180
-	size := width * height * 4
-	src := make([]byte, size)
-	var pool backendVideoBufferPool
-
-	b.ReportAllocs()
-	b.SetBytes(int64(size))
-	b.ResetTimer()
-	for b.Loop() {
-		dst := pool.get(size)
-		copyFFmpegRGBA(dst, src, width*4, width*4, height)
-		pool.put(dst)
-	}
-}
-
 func TestBackendVideoBufferPoolReusesBuffer(t *testing.T) {
 	var pool backendVideoBufferPool
 	first := pool.get(16)

--- a/controller_ffi_test.go
+++ b/controller_ffi_test.go
@@ -140,12 +140,49 @@ type fakeMediaDecoder struct {
 	closed    bool
 }
 
+type blockingMediaDecoder struct {
+	info        backendMediaInfo
+	frame       backendFrame
+	readStarted chan struct{}
+	releaseRead chan struct{}
+	readOnce    sync.Once
+	releaseOnce sync.Once
+}
+
+func (d *blockingMediaDecoder) Info() backendMediaInfo { return d.info }
+
+func (d *blockingMediaDecoder) ReadFrame(context.Context, *backendVideoBufferPool) (backendFrame, error) {
+	d.readOnce.Do(func() { close(d.readStarted) })
+	<-d.releaseRead
+	return d.frame, nil
+}
+
+func (d *blockingMediaDecoder) release() { d.releaseOnce.Do(func() { close(d.releaseRead) }) }
+
+func (*blockingMediaDecoder) Seek(time.Duration) error { return nil }
+func (*blockingMediaDecoder) Close() error             { return nil }
+
+type audioReadResult struct {
+	n   int
+	err error
+}
+
+func startAudioRead(controller *ffiLocalController) <-chan audioReadResult {
+	done := make(chan audioReadResult, 1)
+	go func() {
+		n, err := controller.Read(make([]byte, 4))
+		done <- audioReadResult{n: n, err: err}
+	}()
+	return done
+}
+
 type fakeFFmpegAudioPlayer struct {
 	playing  bool
 	closed   bool
 	position time.Duration
 	volume   float64
 	buffer   time.Duration
+	onClose  func()
 }
 
 func (p *fakeFFmpegAudioPlayer) Play()                         { p.playing = true }
@@ -155,6 +192,9 @@ func (p *fakeFFmpegAudioPlayer) Position() time.Duration       { return p.positi
 func (p *fakeFFmpegAudioPlayer) SetBufferSize(v time.Duration) { p.buffer = v }
 func (p *fakeFFmpegAudioPlayer) SetVolume(v float64)           { p.volume = v }
 func (p *fakeFFmpegAudioPlayer) Close() error {
+	if p.onClose != nil {
+		p.onClose()
+	}
 	p.closed = true
 	p.playing = false
 	return nil
@@ -180,6 +220,185 @@ func (d *fakeMediaDecoder) Seek(position time.Duration) error {
 func (d *fakeMediaDecoder) Close() error {
 	d.closed = true
 	return nil
+}
+
+func TestFFmpegAudioDecodeDoesNotBlockVideoPlayback(t *testing.T) {
+	decoder := &blockingMediaDecoder{
+		info: backendMediaInfo{
+			Duration: time.Second,
+			Video:    &backendVideoInfo{Width: 2, Height: 2, FrameRateNum: 25, FrameRateDen: 1},
+			Audio:    &backendAudioInfo{SampleRate: 48_000, Channels: 2},
+		},
+		frame: backendFrame{
+			Kind:  backendFrameAudio,
+			Audio: backendAudioFrame{PCM: []byte{1, 2, 3, 4}, SampleRate: 48_000, Channels: 2},
+		},
+		readStarted: make(chan struct{}),
+		releaseRead: make(chan struct{}),
+	}
+	t.Cleanup(decoder.release)
+	controller := newFFmpegLocalController(decoder)
+	controller.state = Playing
+	controller.audioPlayer = &fakeFFmpegAudioPlayer{playing: true}
+	controller.waitingForAudioPTS = false
+
+	readDone := startAudioRead(controller)
+
+	select {
+	case <-decoder.readStarted:
+	case <-time.After(time.Second):
+		t.Fatal("audio read did not enter the decoder")
+	}
+
+	videoDone := make(chan error, 1)
+	go func() {
+		_, _, err := controller.CurrentVideoFrame()
+		videoDone <- err
+	}()
+	select {
+	case err := <-videoDone:
+		if err != nil {
+			t.Fatalf("CurrentVideoFrame: %v", err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("CurrentVideoFrame blocked behind an in-flight audio decode")
+	}
+
+	decoder.release()
+	select {
+	case result := <-readDone:
+		if result.n != 4 || result.err != nil {
+			t.Fatalf("audio read = %d, %v; want 4, nil", result.n, result.err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("audio read did not finish")
+	}
+}
+
+func TestFFmpegAudioReadDiscardsFrameDecodedBeforeSeek(t *testing.T) {
+	pixels := make([]byte, 16)
+	decoder := &blockingMediaDecoder{
+		info: backendMediaInfo{
+			Duration: time.Second,
+			Video:    &backendVideoInfo{Width: 2, Height: 2, FrameRateNum: 25, FrameRateDen: 1},
+			Audio:    &backendAudioInfo{SampleRate: 48_000, Channels: 2},
+		},
+		frame: backendFrame{
+			Kind:  backendFrameVideo,
+			Video: backendVideoFrame{RGBA: pixels, Width: 2, Height: 2, Stride: 8},
+		},
+		readStarted: make(chan struct{}),
+		releaseRead: make(chan struct{}),
+	}
+	t.Cleanup(decoder.release)
+	controller := newFFmpegLocalController(decoder)
+	seekStarted := make(chan struct{})
+	controller.audioPlayer = &fakeFFmpegAudioPlayer{onClose: func() { close(seekStarted) }}
+
+	readDone := startAudioRead(controller)
+	select {
+	case <-decoder.readStarted:
+	case <-time.After(time.Second):
+		t.Fatal("audio read did not enter the decoder")
+	}
+
+	seekDone := make(chan error, 1)
+	go func() {
+		_, err := controller.Seek(time.Second)
+		seekDone <- err
+	}()
+	select {
+	case <-seekStarted:
+	case <-time.After(time.Second):
+		t.Fatal("seek did not close the old audio player")
+	}
+
+	decoder.release()
+	select {
+	case err := <-seekDone:
+		if err != nil {
+			t.Fatalf("Seek: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("seek did not finish")
+	}
+	select {
+	case result := <-readDone:
+		if result.n != 0 || !errors.Is(result.err, io.EOF) {
+			t.Fatalf("stale audio read = %d, %v; want 0, io.EOF", result.n, result.err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("stale audio read did not finish")
+	}
+
+	if len(controller.videoQueue) != 0 {
+		t.Fatalf("stale video queue contains %d frames", len(controller.videoQueue))
+	}
+	recycled := controller.videoBuffers.get(len(pixels))
+	if &recycled[0] != &pixels[0] {
+		t.Fatal("stale video buffer was not recycled")
+	}
+}
+
+func TestFFmpegAudioReadDoesNotRetainFrameDecodedBeforeClose(t *testing.T) {
+	pixels := make([]byte, 16)
+	decoder := &blockingMediaDecoder{
+		info: backendMediaInfo{
+			Duration: time.Second,
+			Video:    &backendVideoInfo{Width: 2, Height: 2, FrameRateNum: 25, FrameRateDen: 1},
+			Audio:    &backendAudioInfo{SampleRate: 48_000, Channels: 2},
+		},
+		frame: backendFrame{
+			Kind:  backendFrameVideo,
+			Video: backendVideoFrame{RGBA: pixels, Width: 2, Height: 2, Stride: 8},
+		},
+		readStarted: make(chan struct{}),
+		releaseRead: make(chan struct{}),
+	}
+	t.Cleanup(decoder.release)
+	controller := newFFmpegLocalController(decoder)
+	closeStarted := make(chan struct{})
+	controller.audioPlayer = &fakeFFmpegAudioPlayer{onClose: func() { close(closeStarted) }}
+
+	readDone := startAudioRead(controller)
+	select {
+	case <-decoder.readStarted:
+	case <-time.After(time.Second):
+		t.Fatal("audio read did not enter the decoder")
+	}
+
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- controller.Close() }()
+	select {
+	case <-closeStarted:
+	case <-time.After(time.Second):
+		t.Fatal("Close did not close the audio player")
+	}
+
+	decoder.release()
+	select {
+	case err := <-closeDone:
+		if err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Close did not finish")
+	}
+	select {
+	case result := <-readDone:
+		if result.n != 0 || !errors.Is(result.err, io.EOF) {
+			t.Fatalf("stale audio read = %d, %v; want 0, io.EOF", result.n, result.err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("stale audio read did not finish")
+	}
+
+	controller.videoBuffers.mutex.Lock()
+	pooledBuffers := len(controller.videoBuffers.buffers)
+	controller.videoBuffers.mutex.Unlock()
+	if pooledBuffers != 0 {
+		t.Fatalf("closed controller retained %d video buffers", pooledBuffers)
+	}
 }
 
 func TestFFmpegHasEndedDoesNotReadAFrame(t *testing.T) {


### PR DESCRIPTION
## Summary

This change removes two independent bottlenecks from local playback:

- FFmpeg now scales directly into Avebi's pooled, tightly packed RGBA buffers instead of scaling into an intermediate native frame and copying every row into Go memory.
- Oto audio read-ahead no longer holds the playback-state mutex while FFmpeg decodes the next frame. Native decoder calls remain strictly serialized.

There are no public API changes. Stream playback, media selection, playback controls, audio conversion, and hardware-decoder selection are outside this diff.

## Root cause

The previous video path called `Scaler.Scale`, wrapped the scaler-owned frame, and copied its contents into a pooled Go slice. A 1920x1080 RGBA frame is 8,294,400 bytes; at 60 FPS that extra pass moved approximately 475 MiB/s before `ebiten.Image.WritePixels` uploaded the frame.

For media with audio, Ebitengine/Oto pulls PCM through `ffiLocalController.Read`. That callback previously held the controller mutex across `decoder.ReadFrame`. A native decode can consume most of a frame interval, so Ebitengine's update thread could not inspect the video queue or advance presentation while audio read-ahead was decoding. On the physical Android test this limited the example to approximately 23 TPS / 27 FPS even though MediaCodec and swscale were individually fast enough.

## Implementation

### 1. Scale into the pooled output buffer

`ffiDecoder.convertVideoFrameLocked` now:

1. obtains an exact `width * height * 4` slice from `backendVideoBufferPool`;
2. wraps that slice in a reusable `ffmpeg.Frame` using `Frame.WrapBuffer`;
3. asks `Scaler.ScaleTo` to write RGBA directly into it; and
4. transfers the slice to the returned `backendFrame` without another copy.

The output remains tightly packed RGBA, so the contract consumed by `ebiten.Image.WritePixels` is unchanged.

#### Buffer ownership and native lifetime

- `backendFrame.Video.RGBA` owns the pooled slice after `ScaleTo` returns.
- The controller returns the slice to `backendVideoBufferPool` only when the queued or displayed frame is replaced, discarded, or closed.
- `ffiDecoder.scaleTarget` retains FFmpeg's reference to the most recently wrapped slice. `WrapBuffer` unreferences the previous target before installing the next one.
- A `ScaleTo` failure frees the native reference before returning the slice to the pool.
- `ffiDecoder.Close` frees the final wrapped reference.

The native integration test compares `ffmpeg.WrappedBufferMemoryUsage` before decode, during decode, and after `Close`: exactly one wrapped video buffer may remain pinned while the decoder is open, and the accounting must return to its original baseline after close.

### 2. Separate playback state from native decoder serialization

`ffiLocalController` now gives each lock one responsibility:

| Lock | Responsibility |
| --- | --- |
| `mutex` | Playback state, queues, audio-player state, position, and generation. |
| `readMutex` | Serializes calls to the controller's `io.Reader` implementation. |
| `decoderMutex` | Serializes every native `ReadFrame`, `Seek`, and `Close` call. |

When the audio reader needs another decoded frame, it records `decodeGeneration`, releases the playback mutex, performs the native read under `decoderMutex`, and reacquires the playback mutex before touching queues or state. This keeps `CurrentVideoFrame` and the Ebitengine update loop responsive without allowing concurrent native decoder access.

`decodeGeneration` increments whenever playback is reset or closed. If a read began before a seek, stop, replay, loop reset, or close and completes afterwards, its frame belongs to the old generation: it is discarded, its RGBA buffer is recycled when appropriate, and it cannot enter the new playback state.

`Close` marks the controller closed and invalidates the generation before waiting for the serialized decoder close. A read that was already in flight therefore returns EOF after the native call and cannot repopulate a cleared pool.

## Review guide

The commits are intentionally separated by concern:

1. `backend: scale video into pooled buffers`
   - direct swscale output, error cleanup, final wrapped-frame cleanup, and native pin accounting;
2. `player: keep decoding outside playback lock`
   - lock separation, decoder serialization, and generation invalidation;
3. `test: cover concurrent audio decoding`
   - deterministic blocked-read tests for responsiveness, seek, and close.

The most important invariants to verify are:

- the scaler never writes to a slice concurrently owned by a displayed or queued frame;
- every returned video buffer is either retained by the controller or recycled exactly once;
- `ReadFrame`, `Seek`, and `Close` never overlap on the native decoder;
- no frame decoded before a lifecycle boundary is committed after that boundary; and
- closing a controller cannot leave a pooled RGBA buffer or wrapped Go buffer pinned.

## Tests

The new deterministic tests use a decoder whose `ReadFrame` blocks until released:

- `TestFFmpegAudioDecodeDoesNotBlockVideoPlayback` proves `CurrentVideoFrame` remains available while audio decoding is in flight.
- `TestFFmpegAudioReadDiscardsFrameDecodedBeforeSeek` starts a seek during the blocked read and verifies the stale frame is rejected and recycled.
- `TestFFmpegAudioReadDoesNotRetainFrameDecodedBeforeClose` closes during the blocked read and verifies the stale frame is rejected without repopulating the cleared pool.
- `TestFFmpegBackendMedia` verifies the wrapped-buffer pin count during real decoding and after decoder close.

Validation performed:

- `go test -race -count=1 ./...`
- 20 repeated race-detector runs of the audio/video, seek, and close concurrency tests
- `go vet ./...`
- strict `checkptr` and `GOEXPERIMENT=cgocheck2` native integration tests
- real-media suites and 200-cycle go-ebiten-mcp torture runs against FFmpeg 6, 7, 8, and 9
- final `go test ./...` after updating the branch against current `origin/main`

## Physical Android result

Tested with a clean APK on a physical Android 14 arm64 tablet using a 20-second 1920x1080, 60 FPS H.264/AAC file:

- before: approximately 23 TPS / 27 FPS;
- after: stable 60 TPS / 60 FPS;
- MediaCodec H.264 decoding remained active;
- the stereo 48 kHz AAC test tone was audible, stable, and uninterrupted through the tablet speakers;
- document selection, play, pause, seek, stop, and loop were exercised;
- native heap remained approximately 70 MiB during sustained looping.

This is evidence for the tested device and media, not a general performance guarantee for every codec, resolution, FFmpeg build, or Android device.
