### PR TITLE
player: remove dead code

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,6 @@ applications when that instrumentation is not enabled.
 ## Current limitations
 
 - Live streams are video-only.
-- `NextVideoFrame` is not implemented.
 - Hardware-decoded video is transferred to CPU-accessible frames; zero-copy
   GPU presentation is not implemented.
 - Mobile applications must package their own compatible FFmpeg libraries.

--- a/player_ffi.go
+++ b/player_ffi.go
@@ -17,7 +17,6 @@ var (
 	ErrNoVideo         = errors.New("file doesn't include any video stream")
 	ErrNilAudioContext = errors.New("file has audio stream but audio.Context is not initialized")
 	ErrBadSampleRate   = errors.New("file audio stream and audio context sample rates don't match")
-	ErrTooManyChannels = errors.New("file audio streams with more than 2 channels are not supported")
 )
 
 // Player is a video player backed by go-ffmpeg-ffi.
@@ -163,8 +162,6 @@ func (p *Player) CurrentFrame() (*ebiten.Image, error) {
 }
 
 func (p *Player) LastPresentationOffset() time.Duration { return p.currentPresOffset }
-
-func (p *Player) NextVideoFrame() (*ebiten.Image, error) { panic("unimplemented") }
 
 func (p *Player) Resolution() (int, int) {
 	bounds := p.currentFrame.Bounds()


### PR DESCRIPTION
## Summary

- remove `Player.NextVideoFrame`, which always panicked
- remove `ErrTooManyChannels`, which the current backend never returns
- remove the stale frame-stepping limitation from the README

## Why

Neither exported symbol provides usable behavior. Frame stepping was never
implemented, while decoded audio is now converted to stereo by the FFmpeg
backend instead of rejecting sources with more than two channels.

Keeping these declarations makes the public API promise capabilities and error
handling paths that do not exist.

## API impact

This is a source-breaking cleanup: code referencing `Player.NextVideoFrame` or
`ErrTooManyChannels` no longer compiles. Working playback behavior is unchanged.

## Validation

- `git diff --check`
- `go vet -buildvcs=false ./...`
- `go test -buildvcs=false -race -count=1 -run '^$' -exec /bin/true ./...`
